### PR TITLE
Bug fix: Videos stop playing after modal close

### DIFF
--- a/src/components/pages/Incidents/Modal.js
+++ b/src/components/pages/Incidents/Modal.js
@@ -28,6 +28,7 @@ const IncidentModal = props => {
         <button onClick={showModal}>View All Evidence</button>
       )}
       <Modal
+        destroyOnClose={true}
         onClick={showModal}
         closable={true}
         onCancel={hideModal}


### PR DESCRIPTION
### Description
[Bug Fix: Video modal stops playing when modal closes] (https://trello.com/c/9EN8Od3i)
- [x] Ran locally and passed all tests

